### PR TITLE
[OP-93] django-appconf module pinned to version compatible with django==1.11.15

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,7 @@ django-rest-swagger==2.2.0
 django-solo==1.1.2
 django-threadlocals==0.8
 django-waffle==0.12.0
+django-appconf==1.0.2
 djangorestframework==3.6.4
 djangorestframework-jwt==1.11.0
 drf-extensions==0.3.1


### PR DESCRIPTION
Ticket: https://youtrack.raccoongang.com/issue/OP-93

Fix for deployment error:
```
File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/appconf/base.py", line 107
    class AppConf(metaclass=AppConfMetaClass):"
                           ^
SyntaxError: invalid syntax"
```