### PR TITLE
[OP-276] Task. Add the ability to change the language in ecommerce

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -85,6 +85,7 @@ LANGUAGES = (
     ('ar', _('Arabic')),
     ('es', _('Spanish')),
     ('es-419', _('Spanish (Latin American)')),
+    ('uk', _('Ukrainian')),
 )
 
 LOCALE_PATHS = (

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -475,7 +475,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 # Detailed information at: https://docs.djangoproject.com/en/dev/ref/settings/
 SESSION_COOKIE_NAME = 'ecommerce_sessionid'
 CSRF_COOKIE_NAME = 'ecommerce_csrftoken'
-LANGUAGE_COOKIE_NAME = 'ecommerce_language'
+LANGUAGE_COOKIE_NAME = 'openedx-language-preference'
 SESSION_COOKIE_SECURE = False
 # END COOKIE CONFIGURATION
 


### PR DESCRIPTION
**Description:** In ecommerce/settings/base.py:
- added uk language to LANGUAGE
- changed LANGUAGE_COOKIE_NAME to openedx-language-preference

**Youtrack:** https://youtrack.raccoongang.com/issue/OP-276

**Reviewers**:
- [ ] @oksana-slu 