### PR TITLE
[OP-276] Task. Add the ability to change the language in ecommerce

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -85,6 +85,7 @@ LANGUAGES = (
     ('ar', _('Arabic')),
     ('es', _('Spanish')),
     ('es-419', _('Spanish (Latin American)')),
+    ('uk', _('Ukrainian')),
 )
 
 LOCALE_PATHS = (


### PR DESCRIPTION
**Description:** Added ('uk', _('Ukrainian')) to LANGUAGE flag in ecommerce/ecommerce/settings/base.py

**Youtrack:** https://youtrack.raccoongang.com/issue/OP-276

**Configuration instructions:** 
BASE_COOKIE_DOMAIN (in site configurations e-commerce) 
"raccoongang.com" for dev and stage
"op.ua" for prod

**Reviewers:**
- [ ] @oksana-slu 